### PR TITLE
Use graceful-fs to avoid EMFILE error (too many open files.)

### DIFF
--- a/lib/maildir.js
+++ b/lib/maildir.js
@@ -2,11 +2,11 @@
 
 var util = require('util'),
     events = require('events'),
-    fs = require('fs'),
     os = require('os'),
     crypto = require('crypto'),
     async = require('async'),
     path = require('path'),
+    fs = require('graceful-fs'),
     TMP = 0,
     NEW = 1,
     CUR = 2;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "jshint": "jshint queue.js lib/*.js test/*.js example/*.js"
   },
   "dependencies": {
-    "async": "*"
+    "async": "*",
+    "graceful-fs": "*"
   },
   "devDependencies": {
     "mocha": "1.13.0",


### PR DESCRIPTION
Pretty simple change, I received this error when trying to queue 100000 messages. With this change, they are all queued and processed.